### PR TITLE
remove onBidWon callback from adapter

### DIFF
--- a/modules/orbidderBidAdapter.js
+++ b/modules/orbidderBidAdapter.js
@@ -1,11 +1,8 @@
-import {detectReferer} from '../src/refererDetection.js';
-import {ajax} from '../src/ajax.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import * as utils from '../src/utils.js';
 
 export const spec = {
   code: 'orbidder',
-  bidParams: {},
   orbidderHost: (() => {
     let ret = 'https://orbidder.otto.de';
     try {
@@ -46,7 +43,6 @@ export const spec = {
           params: bidRequest.params
         }
       };
-      spec.bidParams[bidRequest.bidId] = bidRequest.params;
       if (bidderRequest && bidderRequest.gdprConsent) {
         ret.data.gdprConsent = {
           consentString: bidderRequest.gdprConsent.consentString,
@@ -74,21 +70,6 @@ export const spec = {
     }
     return bidResponses;
   },
-
-  onBidWon(bid) {
-    const getRefererInfo = detectReferer(window);
-
-    bid.v = $$PREBID_GLOBAL$$.version;
-    bid.pageUrl = getRefererInfo().referer;
-    if (spec.bidParams[bid.requestId] && (typeof bid.params === 'undefined')) {
-      bid.params = [spec.bidParams[bid.requestId]];
-    }
-    spec.ajaxCall(`${spec.orbidderHost}/win`, JSON.stringify(bid));
-  },
-
-  ajaxCall(endpoint, data) {
-    ajax(endpoint, null, data, { withCredentials: true });
-  }
 };
 
 registerBidder(spec);

--- a/test/spec/modules/orbidderBidAdapter_spec.js
+++ b/test/spec/modules/orbidderBidAdapter_spec.js
@@ -153,40 +153,6 @@ describe('orbidderBidAdapter', () => {
     });
   });
 
-  describe('onCallbackHandler', () => {
-    let ajaxStub;
-    const bidObj = {
-      adId: 'testId',
-      test: 1,
-      pageUrl: 'www.someurl.de',
-      referrer: 'www.somereferrer.de',
-      requestId: '123req456'
-    };
-
-    spec.bidParams['123req456'] = {'accountId': '123acc456'};
-
-    let bidObjClone = deepClone(bidObj);
-    bidObjClone.v = $$PREBID_GLOBAL$$.version;
-    bidObjClone.pageUrl = detectReferer(window)().referer;
-    bidObjClone.params = [{'accountId': '123acc456'}];
-
-    beforeEach(() => {
-      ajaxStub = sinon.stub(spec, 'ajaxCall');
-    });
-
-    afterEach(() => {
-      ajaxStub.restore();
-    });
-
-    it('calls orbidder\'s callback endpoint', () => {
-      spec.onBidWon(bidObj);
-      expect(ajaxStub.calledOnce).to.equal(true);
-      expect(ajaxStub.firstCall.args[0].indexOf('https://')).to.equal(0);
-      expect(ajaxStub.firstCall.args[0]).to.equal(`${spec.orbidderHost}/win`);
-      expect(ajaxStub.firstCall.args[1]).to.equal(JSON.stringify(bidObjClone));
-    });
-  });
-
   describe('interpretResponse', () => {
     it('should get correct bid response', () => {
       const serverResponse = [


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
