### PR TITLE
[SIGGI-1431] update to Prebid.js - v.5.0

### DIFF
--- a/modules/orbidderBidAdapter.js
+++ b/modules/orbidderBidAdapter.js
@@ -74,9 +74,9 @@ export const spec = {
           bidResponse[requiredKey] = bid[requiredKey];
         }
 
-        if (Array.isArray(bid.adomain)) {
+        if (Array.isArray(bid.advertiserDomains)) {
           bidResponse.meta = {
-            advertiserDomains: bid.adomain
+            advertiserDomains: bid.advertiserDomains
           }
         }
 

--- a/modules/orbidderBidAdapter.js
+++ b/modules/orbidderBidAdapter.js
@@ -1,5 +1,6 @@
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import { getStorageManager } from '../src/storageManager.js';
+import * as utils from '../src/utils.js';
 
 const storageManager = getStorageManager();
 
@@ -31,6 +32,8 @@ export const spec = {
       if (bidderRequest && bidderRequest.refererInfo) {
         referer = bidderRequest.refererInfo.referer || '';
       }
+
+      bidRequest.params.bidfloor = getBidFloor(bidRequest);
 
       const ret = {
         url: `${hostname}/bid`,
@@ -76,5 +79,26 @@ export const spec = {
     return bidResponses;
   },
 };
+
+/**
+ * Get bid floor from Price Floors Module
+ * @param {Object} bid
+ * @returns {float||undefined}
+ */
+function getBidFloor(bid) {
+  if (!utils.isFn(bid.getFloor)) {
+    return bid.params.bidfloor;
+  }
+
+  const floor = bid.getFloor({
+    currency: 'EUR',
+    mediaType: '*',
+    size: '*'
+  });
+  if (utils.isPlainObject(floor) && !isNaN(floor.floor) && floor.currency === 'EUR') {
+    return floor.floor;
+  }
+  return undefined;
+}
 
 registerBidder(spec);

--- a/modules/orbidderBidAdapter.js
+++ b/modules/orbidderBidAdapter.js
@@ -1,5 +1,3 @@
-/* eslint-disable */
-
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import { getStorageManager } from '../src/storageManager.js';
 import * as utils from '../src/utils.js';
@@ -76,7 +74,7 @@ export const spec = {
           bidResponse[requiredKey] = bid[requiredKey];
         }
 
-        if(Array.isArray(bid.adomain)) {
+        if (Array.isArray(bid.adomain)) {
           bidResponse.meta = {
             advertiserDomains: bid.adomain
           }

--- a/modules/orbidderBidAdapter.js
+++ b/modules/orbidderBidAdapter.js
@@ -1,3 +1,5 @@
+/* eslint-disable */
+
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import { getStorageManager } from '../src/storageManager.js';
 import * as utils from '../src/utils.js';
@@ -73,6 +75,13 @@ export const spec = {
           }
           bidResponse[requiredKey] = bid[requiredKey];
         }
+
+        if(Array.isArray(bid.adomain)) {
+          bidResponse.meta = {
+            advertiserDomains: bid.adomain
+          }
+        }
+
         bidResponses.push(bidResponse);
       });
     }

--- a/test/spec/modules/orbidderBidAdapter_spec.js
+++ b/test/spec/modules/orbidderBidAdapter_spec.js
@@ -104,7 +104,7 @@ describe('orbidderBidAdapter', () => {
       expect(request.data.pageUrl).to.equal('https://localhost:9876/');
       // expect(request.data.referrer).to.equal('');
       Object.keys(defaultBidRequest).forEach((key) => {
-        expect(defaultBidRequest[key]).to.equal(request.data[key]);
+        expect(request.data[key]).to.deep.equal(defaultBidRequest[key]);
       });
     });
 

--- a/test/spec/modules/orbidderBidAdapter_spec.js
+++ b/test/spec/modules/orbidderBidAdapter_spec.js
@@ -201,7 +201,7 @@ describe('orbidderBidAdapter', () => {
           'ttl': 60,
           'netRevenue': true,
           'currency': 'EUR',
-          'adomain': ['cm.tavira.pt']
+          'advertiserDomains': ['cm.tavira.pt']
         }
       ];
 

--- a/test/spec/modules/orbidderBidAdapter_spec.js
+++ b/test/spec/modules/orbidderBidAdapter_spec.js
@@ -189,6 +189,47 @@ describe('orbidderBidAdapter', () => {
       });
     });
 
+    it('should get correct bid response with advertiserDomains', () => {
+      const serverResponse = [
+        {
+          'width': 300,
+          'height': 250,
+          'creativeId': '29681110',
+          'ad': '<!-- Creative -->',
+          'cpm': 0.5,
+          'requestId': '30b31c1838de1e',
+          'ttl': 60,
+          'netRevenue': true,
+          'currency': 'EUR',
+          'adomain': ['cm.tavira.pt']
+        }
+      ];
+
+      const expectedResponse = [
+        {
+          'requestId': '30b31c1838de1e',
+          'cpm': 0.5,
+          'creativeId': '29681110',
+          'width': 300,
+          'height': 250,
+          'ttl': 60,
+          'currency': 'EUR',
+          'ad': '<!-- Creative -->',
+          'netRevenue': true,
+          'meta': {
+            'advertiserDomains': ['cm.tavira.pt']
+          }
+        }
+      ];
+
+      const result = spec.interpretResponse({body: serverResponse});
+
+      expect(result.length).to.equal(expectedResponse.length);
+      Object.keys(expectedResponse[0]).forEach((key) => {
+        expect(result[0][key]).to.deep.equal(expectedResponse[0][key]);
+      });
+    });
+
     it('handles broken server response', () => {
       const serverResponse = [
         {


### PR DESCRIPTION
## Type of change
- [x] Feature
 
## Description of change
Extended orbidderBidAdapter with supporting of advertiserDomains [issue#6650](https://github.com/prebid/Prebid.js/issues/6650) and getFloor [issue#6465](https://github.com/prebid/Prebid.js/issues/6465) for version compatibility Prebid.js - v.5.0

- realtime-siggi@otto.de
- [x] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
Commits:
- [Added getFloor](https://github.com/siggi-otto/Prebid.js/commit/008e7395ea305f5c43d759fd69ecedf54e08ad91)
- [Added advertiserDomains](https://github.com/siggi-otto/Prebid.js/commit/a2940f390037b4397006044e6800e1b3d24c6543)
